### PR TITLE
chore(test): enable FactoryGirl syntax

### DIFF
--- a/spec/contexts/user_auth_context_spec.rb
+++ b/spec/contexts/user_auth_context_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe UserAuthContext, type: :context do
-  let(:user) { FactoryGirl.create :unconfirmed_user }
+  let(:user) { create :unconfirmed_user }
   let(:omniauth_data) { omniauth_mock(:facebook) }
   let!(:email) { omniauth_data['info']['email'] }
 
@@ -23,7 +23,7 @@ describe UserAuthContext, type: :context do
       end
     end
     it 'user2 has the same email' do
-      FactoryGirl.create :user, email: email
+      create :user, email: email
       expect {
         @result = subject
       }.not_to change { user.reload.authorizations.count }
@@ -55,7 +55,7 @@ describe UserAuthContext, type: :context do
       end
     end
     context 'already bind to user2' do
-      let!(:user2) { FactoryGirl.create :user, email: email }
+      let!(:user2) { create :user, email: email }
       before { described_class.new(omniauth_data, user2).perform }
 
       it 'authorizations count' do

--- a/spec/controllers/admin/base_controller_spec.rb
+++ b/spec/controllers/admin/base_controller_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe Admin::BaseController, type: :request do
 
   context '.authenticate_admin_user!' do
     it 'success' do
-      signin_user(FactoryGirl.create(:admin_user))
+      signin_user(create(:admin_user))
       get '/admin'
       expect(response).to be_success
     end
 
     it 'not admin' do
-      signin_user(FactoryGirl.create(:user))
+      signin_user(create(:user))
       get '/admin'
       expect(response).not_to be_success
     end

--- a/spec/controllers/admin/categories_controller_spec.rb
+++ b/spec/controllers/admin/categories_controller_spec.rb
@@ -13,7 +13,7 @@
 require 'rails_helper'
 
 RSpec.describe Admin::CategoriesController, type: :request do
-  let(:category) { FactoryGirl.create :category }
+  let(:category) { create :category }
 
   before { signin_user }
 
@@ -77,7 +77,7 @@ RSpec.describe Admin::CategoriesController, type: :request do
   end
 
   it 'DELETE /admin/categories/123' do
-    category = FactoryGirl.create :category
+    category = create :category
     expect {
       delete "/admin/categories/#{category.id}"
     }.to change { Category.count }.by(-1)

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Admin::UsersController, type: :request do
   end
 
   it 'DELETE /admin/users/123' do
-    user = FactoryGirl.create :user
+    user = create :user
     expect {
       delete "/admin/users/#{user.id}"
     }.to change { User.count }.by(-1)

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -29,7 +29,7 @@ describe AuthorizationsController, type: :request do
     end
 
     context 'user auth fb & signed in' do
-      let(:user2) { FactoryGirl.create :user, email: omniauth_mock(:facebook)[:info][:email] }
+      let(:user2) { create :user, email: omniauth_mock(:facebook)[:info][:email] }
       before { fb_auth }
       before { follow_redirect! }
       before { @user = User.last }

--- a/spec/models/authorization_spec.rb
+++ b/spec/models/authorization_spec.rb
@@ -17,6 +17,6 @@ require 'rails_helper'
 
 RSpec.describe Authorization, type: :model do
   it 'FactoryGirl' do
-    expect(FactoryGirl.create(:authorization)).not_to be_new_record
+    expect(create(:authorization)).not_to be_new_record
   end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -13,12 +13,12 @@
 require 'rails_helper'
 
 RSpec.describe Category, type: :model do
-  let(:category) { FactoryGirl.create :category }
+  let(:category) { create :category }
 
   it 'FactoryGirl' do
     expect {
-      FactoryGirl.create :category
-      FactoryGirl.create :category
+      create :category
+      create :category
     }.to change { Category.count }.by(2)
   end
 
@@ -37,7 +37,7 @@ RSpec.describe Category, type: :model do
 
   it 'sortable' do
     category.reload.update_attribute :sort, :up
-    category2 = FactoryGirl.create :category
+    category2 = create :category
     expect {
       category2.update_attribute :sort, :up
     }.to change { described_class.sorted.try(:first).try(:id) }.to eq category2.id

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,10 +27,10 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  let(:user) { FactoryGirl.create :user }
+  let(:user) { create :user }
 
   it 'FactoryGirl' do
     expect(user).not_to be_new_record
-    expect(FactoryGirl.create(:user_with_avatar).avatar.url).to be_present
+    expect(create(:user_with_avatar).avatar.url).to be_present
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,6 +55,7 @@ RSpec.configure do |config|
   config.include DataMaker
   config.include RequestClient, type: :request
   config.include HtmlMatchers, type: :request
+  config.include FactoryGirl::Syntax::Methods
 
   config.before(:each){ webmock_all! }
   config.before(:each){ Redis.current.flushdb }

--- a/spec/support/request_client.rb
+++ b/spec/support/request_client.rb
@@ -5,7 +5,7 @@ module RequestClient
   end
 
   def signin_user(user = nil)
-    user ||= FactoryGirl.create(:admin_user)
+    user ||= create(:admin_user)
     post '/users/sign_in', params: { user: { email: user.email, password: user.password } }
     @current_user = user if response.status == 302
   end


### PR DESCRIPTION
All `factory_girl` methods won't need to be prefaced with `FactoryGirl`.