### PR TITLE
feat: 為 admin 實作 Google MFA 功能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -136,3 +136,5 @@ gem 'sitemap_generator'
 
 # middleware
 gem 'rack-cors', require: 'rack/cors'
+
+gem 'google-authenticator-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,13 @@ GEM
     gherkin (4.1.3)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    google-authenticator-rails (1.4.0)
+      actionpack
+      activerecord
+      google-qr
+      rails
+      rotp (= 1.6.1)
+    google-qr (0.2.2)
     hashdiff (0.3.7)
     hashie (3.5.6)
     http-cookie (1.0.3)
@@ -332,6 +339,7 @@ GEM
       rgeo (~> 0.3)
     rollbar (2.15.5)
       multi_json
+    rotp (1.6.1)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -489,6 +497,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   fog-aws
+  google-authenticator-rails
   http_logger
   jbuilder (~> 2.0)
   jquery-rails

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -4,6 +4,7 @@ class Admin::BaseController < ApplicationController
 
   before_action :authenticate_user!
   before_action :authenticate_admin_user!
+  before_action :check_mfa
   before_action :set_meta
 
   add_breadcrumb 'Admin', :admin_root_path
@@ -26,5 +27,12 @@ class Admin::BaseController < ApplicationController
 
   def authenticate_admin_user!
     redirect_to root_path unless current_user.admin?
+  end
+
+  def check_mfa
+    return true unless current_user.mfa_secret?
+    if !(user_mfa_session = UserMfaSession.find) && (user_mfa_session ? user_mfa_session.record == current_user : !user_mfa_session)
+      redirect_to new_admin_user_mfa_session_path
+    end
   end
 end

--- a/app/controllers/admin/user_mfa_sessions_controller.rb
+++ b/app/controllers/admin/user_mfa_sessions_controller.rb
@@ -1,0 +1,20 @@
+class Admin::UserMfaSessionsController < Admin::BaseController
+  skip_before_action :check_mfa
+
+  layout 'admin_landing'
+
+  def new
+  end
+
+  def create
+    user = current_user # grab your currently logged in user
+    if user.google_authentic?(params[:user][:mfa_code])
+      user.setup_mfa_token
+      UserMfaSession.create(user)
+      redirect_to admin_root_path
+    else
+      flash[:error] = "Wrong code"
+      render :new
+    end
+  end
+end

--- a/app/models/admin/user.rb
+++ b/app/models/admin/user.rb
@@ -22,6 +22,8 @@
 #  updated_at             :datetime
 #  admin                  :boolean          default(FALSE)
 #  avatar                 :string
+#  mfa_secret             :string
+#  mfa_token              :string
 #
 
 class Admin::User < ::User

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,9 +22,15 @@
 #  updated_at             :datetime
 #  admin                  :boolean          default(FALSE)
 #  avatar                 :string
+#  mfa_secret             :string
+#  mfa_token              :string
 #
 
 class User < ApplicationRecord
+  attr_accessor :mfa_code
+  acts_as_google_authenticated issuer: ENV['APP_NAME'],
+                               google_secret_column: :mfa_secret,
+                               lookup_token: :mfa_token
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable, :confirmable,
@@ -33,4 +39,8 @@ class User < ApplicationRecord
 
   mount_uploader :avatar, AvatarUploader
 
+  def setup_mfa_token
+    return if self.mfa_token.present?
+    update(mfa_token: ROTP::Base32.random_base32)
+  end
 end

--- a/app/models/user_mfa_session.rb
+++ b/app/models/user_mfa_session.rb
@@ -1,0 +1,4 @@
+class UserMfaSession <  GoogleAuthenticatorRails::Session::Base
+  # no real code needed here
+  # end
+end

--- a/app/views/admin/user_mfa_sessions/new.html.slim
+++ b/app/views/admin/user_mfa_sessions/new.html.slim
@@ -1,0 +1,4 @@
+= admin_form_for current_user, url: admin_user_mfa_sessions_path, method: :post, wrapper: :admin_landing do |f|
+  = f.input :mfa_code, placeholder: '驗證碼', required: true
+  = f.full_size_submit '驗證'
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,8 @@ Rails.application.routes.draw do
         post :restore
       end
     end
+
+    resources :user_mfa_sessions
   end
 
   namespace :api do

--- a/db/migrate/20171129015352_add_google_secret_to_user.rb
+++ b/db/migrate/20171129015352_add_google_secret_to_user.rb
@@ -1,0 +1,6 @@
+class AddGoogleSecretToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :mfa_secret, :string
+    add_column :users, :mfa_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151216161107) do
+ActiveRecord::Schema.define(version: 20171129015352) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,6 +79,8 @@ ActiveRecord::Schema.define(version: 20151216161107) do
     t.datetime "updated_at"
     t.boolean  "admin",                  default: false
     t.string   "avatar"
+    t.string   "mfa_secret"
+    t.string   "mfa_token"
     t.index ["admin"], name: "index_users_on_admin", using: :btree
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/spec/acceptance/admin/index.feature
+++ b/spec/acceptance/admin/index.feature
@@ -10,9 +10,17 @@ Feature: 基本驗證
         Then 頁面轉跳
       When 前往 /sidekiq
         Then 頁面回應 404
-  Scenario: 非 admin 登入
+  Scenario: admin 登入
     Given 管理者 登入
       When 前往 /admin
         Then 頁面回應 正常
       When 前往 /sidekiq
+        Then 頁面回應 正常
+  Scenario: admin 且啟動二階段認證 登入
+    Given 二階段認證者 登入
+      When 前往 /admin
+        Then 頁面轉跳至 /admin/user_mfa_sessions/new
+    Given 二階段認證者 登入
+      And 通過MFA驗證
+        When 前往 /admin
         Then 頁面回應 正常

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -37,6 +37,10 @@ FactoryBot.define do
       admin true
     end
 
+    trait :enable_mfa do
+      mfa_secret { ROTP::Base32.random_base32 }
+    end
+
     trait :unconfirmed do
       confirmed_at nil
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -22,6 +22,8 @@
 #  updated_at             :datetime
 #  admin                  :boolean          default(FALSE)
 #  avatar                 :string
+#  mfa_secret             :string
+#  mfa_token              :string
 #
 
 FactoryBot.define do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,6 +22,8 @@
 #  updated_at             :datetime
 #  admin                  :boolean          default(FALSE)
 #  avatar                 :string
+#  mfa_secret             :string
+#  mfa_token              :string
 #
 
 require 'rails_helper'

--- a/spec/steps/response_steps.rb
+++ b/spec/steps/response_steps.rb
@@ -28,8 +28,8 @@ step '頁面轉跳' do
   expect(response).to be_redirect
 end
 
-step '頁面轉跳至 :path' do |path|
-  expect(response).to redirect_to(path)
+step '頁面轉跳至 :page' do |page|
+  expect(response).to redirect_to(page)
 end
 
 step '頁面包含 :content' do |content|

--- a/spec/steps/user_login_steps.rb
+++ b/spec/steps/user_login_steps.rb
@@ -3,9 +3,17 @@ step ':user 登入' do |user|
   signin_user(@current_user)
 end
 
+step '通過MFA驗證' do
+  pass_mfa
+end
+
 placeholder :user do
   match /user/ do
     create(:user)
+  end
+
+  match /二階段認證者/ do
+    create(:user, :admin, :enable_mfa)
   end
 
   match /管理者/ do

--- a/spec/support/request_client.rb
+++ b/spec/support/request_client.rb
@@ -10,6 +10,12 @@ module RequestClient
     @current_user = user if response.status == 302
   end
 
+  def pass_mfa
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@current_user)
+    expect(@current_user).to receive(:google_authentic?).and_return(true)
+    post '/admin/user_mfa_sessions', params: { user: { mfa_code: '1234' } }
+  end
+
   def current_user
     @current_user
   end


### PR DESCRIPTION
這個功能實裝後，還需要「打開」才能使用

`User#set_google_secret`

這個應該實作在管理員的 profile 頁面，讓使用者可以打開

## 如何在本機端測試

- 跑完 migration 後
- 將其中一個 admin 為它執行 `set_google_secret`
- 執行 `User#google_qr_uri` 來獲取 QR code 的頁面，打開後掃進你的 Google Authenticator APP 裡
- 進行登入，第一次登入的話會來到 `/admin/user_mfa_sessions/new` 裡進行 mfa 驗證
- 驗證成功後會回到 `/admin` 頁